### PR TITLE
Fix wrong avatar URL parameter being used in subscribe request payload

### DIFF
--- a/src/main/Application/Subscriptions/SubscriptionApplicationService.cs
+++ b/src/main/Application/Subscriptions/SubscriptionApplicationService.cs
@@ -22,7 +22,7 @@ namespace ei8.Cortex.Diary.Application.Subscriptions
 
 			await this.subscriptionClient.AddSubscriptionAsync(avatarUrl, new BrowserSubscriptionInfo()
 			{
-				AvatarUrl = avatarUrl,
+				AvatarUrl = avatarSnapshotUrl,
 				Name = deviceName,
 				PushAuth = pushAuth,	
 				PushEndpoint = pushEndpoint,


### PR DESCRIPTION
Use `avatarSnapshotUrl` - the actual avatar URL to susbcribe to, instead of `avatarUrl` - the trimmed "base URL" for the avatar